### PR TITLE
Cleanups and reindentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	cf-agent -KI -DTEST -f ./example.cf

--- a/example.cf
+++ b/example.cf
@@ -1,13 +1,20 @@
 body common control
 {
-      inputs => { "/tmp/masterfiles/lib/3.6/files.cf", "./firewalld.cf" };
+      inputs => { "$(sys.libdir)/stdlib.cf", "$(includes.dir)/firewalld.cf" };
       bundlesequence => { "firewalld" };
+}
+
+bundle common includes
+{
+  vars:
+      "dir" string => $(this.promise_dirname);
 }
 
 bundle agent firewalld
 {
   methods:
     any::
+      "prep"    usebundle => firewalld_config;
       "config"  usebundle => example_firewalld_conf;
       "service" usebundle => example_firewalld_service;
       "zone"    usebundle => example_firewalld_zone;
@@ -18,32 +25,32 @@ bundle agent example_firewalld_conf
 {
   vars:
       "my_configuration"
-          string => '{
+          data => parsejson('{
 		       "default_zone":    "public",
 		       "minimal_mark":    "100",
 		       "cleanup_on_exit": "yes",
 		       "lock_down":       "no",
 		       "ipv6_rpfilter":   "yes",
-		     }';
+		     }');
 
   methods:
-      "any" usebundle => firewalld_configuration($(my_configuration));
+      "any" usebundle => firewalld_configuration(@(my_configuration));
 }
 
 bundle agent example_firewalld_service
 {
   vars:
       "example_service1"
-          string => '{
+          data => parsejson('{
                        "short": "Example Service1",
                        "description": "Example service 1",
                        "port": [
                                  { "protocol": "tcp", "port": "1234" },
 				 ],
-                    }';
+                    }');
 
       "example_service2"
-          string => '{
+          data => parsejson('{
                        "short": "Example Service2",
                        "description": "Example service 2",
                        "port": [
@@ -52,10 +59,10 @@ bundle agent example_firewalld_service
                                  { "protocol": "tcp", "port": "5678" },
 				 ],
 		       "module": [ "nf_conntrack", "nf_nat" ],
-                     }';
+                     }');
 
       "example_service3"
-          string => '{
+          data => parsejson('{
                        "short": "Example Service3",
                        "description": "Example service 3",
                        "port": [
@@ -65,19 +72,19 @@ bundle agent example_firewalld_service
 					 "ipv4?": { "value": "10.0.0.123" },
 					 "ipv6?": { "value": "aaaa:bbbb::123" },
 				       }
-                     }';
+                     }');
 
   methods:
-      "any" usebundle => create_firewalld_service("example_service1", $(example_service1));
-      "any" usebundle => create_firewalld_service("example_service2", $(example_service2));
-      "any" usebundle => create_firewalld_service("example_service3", $(example_service3));
+      "any" usebundle => create_firewalld_service("example_service1", @(example_service1));
+      "any" usebundle => create_firewalld_service("example_service2", @(example_service2));
+      "any" usebundle => create_firewalld_service("example_service3", @(example_service3));
 }
 
 bundle agent example_firewalld_zone
 {
   vars:
       "example_zone1"
-          string => '{
+          data => parsejson('{
                       "short": "Example Zone1",
                       "description": "Example Zone 1",
                       "source": [
@@ -88,17 +95,17 @@ bundle agent example_firewalld_zone
                                   "ssh",
                                   "example_service1",
                                  ]
-                    }';
+                    }');
 
       "example_zone2"
-          string => '{
+          data => parsejson('{
                        "short": "Example Zone1",
                        "description": "Example Zone 1",
 		       "masquerade?": true,
-                    }';
+                    }');
 
       "example_zone3"
-          string => '{
+          data => parsejson('{
                        "short": "Example Zone3",
                        "description": "Example Zone 3",
 		       "target?": { "value": "ACCEPT" },
@@ -132,10 +139,10 @@ bundle agent example_firewalld_zone
 					 },
 					 { "port": "5678", "protocol": "tcp" },
 					 ],
-                    }';
+                    }');
 
       "example_zone4"
-          string => '{
+          data => parsejson('{
                        "short": "Example Zone4",
                        "description": "Example Zone 4",
                        "source": [
@@ -166,20 +173,20 @@ bundle agent example_firewalld_zone
 				   "audit?": true,
 				 },
 				 ]
-                     }';
+                     }');
 
   methods:
-      "any" usebundle => create_firewalld_zone("example_zone1", $(example_zone1));
-      "any" usebundle => create_firewalld_zone("example_zone2", $(example_zone2));
-      "any" usebundle => create_firewalld_zone("example_zone3", $(example_zone3));
-      "any" usebundle => create_firewalld_zone("example_zone4", $(example_zone4));
+      "any" usebundle => create_firewalld_zone("example_zone1", @(example_zone1));
+      "any" usebundle => create_firewalld_zone("example_zone2", @(example_zone2));
+      "any" usebundle => create_firewalld_zone("example_zone3", @(example_zone3));
+      "any" usebundle => create_firewalld_zone("example_zone4", @(example_zone4));
 }
 
 bundle agent example_firewalld_direct
 {
   vars:
       "example_direct"
-          string => '{
+          data => parsejson('{
                        "chain": [{
 				   "ipv": "ipv4",
 				   "table": "raw",
@@ -221,8 +228,8 @@ bundle agent example_firewalld_direct
 					 "ipv": "ipv6",
 					 "args": "-s aaaa:bbbb::/40 -j ACCEPT",
 				       },],
-                    }';
+                    }');
 
   methods:
-      "any" usebundle => create_firewalld_direct($(example_direct));
+      "any" usebundle => create_firewalld_direct(@(example_direct));
 }

--- a/example.cf
+++ b/example.cf
@@ -25,13 +25,13 @@ bundle agent example_firewalld_conf
 {
   vars:
       "my_configuration"
-          data => parsejson('{
+      data => parsejson('{
 		       "default_zone":    "public",
 		       "minimal_mark":    "100",
 		       "cleanup_on_exit": "yes",
 		       "lock_down":       "no",
 		       "ipv6_rpfilter":   "yes",
-		     }');
+      }');
 
   methods:
       "any" usebundle => firewalld_configuration(@(my_configuration));
@@ -41,16 +41,16 @@ bundle agent example_firewalld_service
 {
   vars:
       "example_service1"
-          data => parsejson('{
+      data => parsejson('{
                        "short": "Example Service1",
                        "description": "Example service 1",
                        "port": [
                                  { "protocol": "tcp", "port": "1234" },
 				 ],
-                    }');
+      }');
 
       "example_service2"
-          data => parsejson('{
+      data => parsejson('{
                        "short": "Example Service2",
                        "description": "Example service 2",
                        "port": [
@@ -59,10 +59,10 @@ bundle agent example_firewalld_service
                                  { "protocol": "tcp", "port": "5678" },
 				 ],
 		       "module": [ "nf_conntrack", "nf_nat" ],
-                     }');
+      }');
 
       "example_service3"
-          data => parsejson('{
+      data => parsejson('{
                        "short": "Example Service3",
                        "description": "Example service 3",
                        "port": [
@@ -71,8 +71,8 @@ bundle agent example_firewalld_service
 		       "destination?": {
 					 "ipv4?": { "value": "10.0.0.123" },
 					 "ipv6?": { "value": "aaaa:bbbb::123" },
-				       }
-                     }');
+		       }
+      }');
 
   methods:
       "any" usebundle => create_firewalld_service("example_service1", @(example_service1));
@@ -84,7 +84,7 @@ bundle agent example_firewalld_zone
 {
   vars:
       "example_zone1"
-          data => parsejson('{
+      data => parsejson('{
                       "short": "Example Zone1",
                       "description": "Example Zone 1",
                       "source": [
@@ -95,17 +95,17 @@ bundle agent example_firewalld_zone
                                   "ssh",
                                   "example_service1",
                                  ]
-                    }');
+      }');
 
       "example_zone2"
-          data => parsejson('{
+      data => parsejson('{
                        "short": "Example Zone1",
                        "description": "Example Zone 1",
 		       "masquerade?": true,
-                    }');
+      }');
 
       "example_zone3"
-          data => parsejson('{
+      data => parsejson('{
                        "short": "Example Zone3",
                        "description": "Example Zone 3",
 		       "target?": { "value": "ACCEPT" },
@@ -139,10 +139,10 @@ bundle agent example_firewalld_zone
 					 },
 					 { "port": "5678", "protocol": "tcp" },
 					 ],
-                    }');
+      }');
 
       "example_zone4"
-          data => parsejson('{
+      data => parsejson('{
                        "short": "Example Zone4",
                        "description": "Example Zone 4",
                        "source": [
@@ -164,16 +164,16 @@ bundle agent example_firewalld_zone
                                                       "protocol": "tcp",
                                                       "to-port?": { "port": "9999" },
                                                       "to-addr?": { "address": "192.168.0.123" },
-                                                    }
+                                   }
                                    "log?": {
                                              "prefix?": { "value": "foo" },
                                              "level?": { "value": "debug" },
 					     "limit?": { "value": "1000" },
-                                           }
+                                   }
 				   "audit?": true,
 				 },
 				 ]
-                     }');
+      }');
 
   methods:
       "any" usebundle => create_firewalld_zone("example_zone1", @(example_zone1));
@@ -186,19 +186,19 @@ bundle agent example_firewalld_direct
 {
   vars:
       "example_direct"
-          data => parsejson('{
+      data => parsejson('{
                        "chain": [{
 				   "ipv": "ipv4",
 				   "table": "raw",
 				   "chain": "blacklist",
-				 },],
+		       },],
 		       "rule": [{
 				  "ipv": "ipv4",
 				  "table": "raw",
 				  "chain": "PREROUTING",
 				  "priority": "0",
 				  "args": "-s 192.168.1.0/24 -j blacklist",
-				},
+		       },
 				{
 				  "ipv": "ipv4",
 				  "table": "raw",
@@ -223,12 +223,12 @@ bundle agent example_firewalld_direct
 		       "passthrough": [{
 					 "ipv": "ipv4",
 					 "args": "-s 10.0.0.0/24 -j ACCEPT",
-				       },
+		       },
 				       {
 					 "ipv": "ipv6",
 					 "args": "-s aaaa:bbbb::/40 -j ACCEPT",
 				       },],
-                    }');
+      }');
 
   methods:
       "any" usebundle => create_firewalld_direct(@(example_direct));

--- a/firewalld.cf
+++ b/firewalld.cf
@@ -1,11 +1,19 @@
+bundle common firewalld_config
+{
+  vars:
+      "directory" string => ifelse("TEST", "/tmp/firewalld",
+                                  "/etc/firewalld/services");
+      "service_directory" string => "$(directory)/services";
+      "zone_directory" string => "$(directory)/zones";
+}
+
 #
 # Create a firewalld service
 #
 bundle agent create_firewalld_service(name,data)
 {
   files:
-      #"/etc/firewalld/services/$(name).xml"
-      "/tmp/$(name).xml"
+      "$(firewalld_config.service_directory)/$(name).xml"
           create          => "true",
           handle          => "created_firewalld_$(name)_service",
           pathtype        => "literal",
@@ -13,7 +21,7 @@ bundle agent create_firewalld_service(name,data)
           perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
           classes         => if_repaired("repaired_firewalld"),
           template_method => "mustache",
-          template_data   => parsejson("$(data)"),
+          template_data   => mergedata(data),
           comment         => "Create firewalld service '$(name)'";
 
   commands:
@@ -27,8 +35,7 @@ bundle agent create_firewalld_service(name,data)
 bundle agent delete_firewalld_service(name)
 {
   files:
-      #"/etc/firewalld/services/$(name).xml"
-      "/tmp/$(name).xml"
+      "$(firewalld_config.service_directory)/$(name).xml"
           delete   => tidy,
           handle   => "deleted_firewalld_$(name)_service",
           pathtype => "literal",
@@ -46,8 +53,7 @@ bundle agent delete_firewalld_service(name)
 bundle agent create_firewalld_zone(name,data)
 {
   files:
-      #"/etc/firewalld/zones/$(name).xml"
-      "/tmp/$(name).xml"
+      "$(firewalld_config.zone_directory)/$(name).xml"
           create          => "true",
           handle          => "created_firewalld_$(name)_zone",
           pathtype        => "literal",
@@ -55,7 +61,7 @@ bundle agent create_firewalld_zone(name,data)
           perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
           classes         => if_repaired("repaired_firewalld"),
           template_method => "mustache",
-          template_data   => parsejson("$(data)"),
+          template_data   => mergedata(data),
           comment         => "Create firewalld zone '$(name)'";
 
   commands:
@@ -69,8 +75,7 @@ bundle agent create_firewalld_zone(name,data)
 bundle agent delete_firewalld_zone(name)
 {
   files:
-      #"/etc/firewalld/zones/$(name).xml"
-      "/tmp/$(name).xml"
+      "$(firewalld_config.zone_directory)/$(name).xml"
           delete   => tidy,
           handle   => "deleted_firewalld_$(name)_zone",
           pathtype => "literal",
@@ -88,8 +93,7 @@ bundle agent delete_firewalld_zone(name)
 bundle agent create_firewalld_direct(data)
 {
   files:
-      #"/etc/firewalld/direct.xml"
-      "/tmp/direct.xml"
+      "$(firewalld_config.directory)/direct.xml"
           create          => "true",
           handle          => "created_firewalld_direct.xml",
           pathtype        => "literal",
@@ -97,7 +101,7 @@ bundle agent create_firewalld_direct(data)
           perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
           classes         => if_repaired("repaired_firewalld"),
           template_method => "mustache",
-          template_data   => parsejson("$(data)"),
+          template_data   => mergedata(data),
           comment         => "Create firewalld direct.xml";
 
   commands:
@@ -111,8 +115,7 @@ bundle agent create_firewalld_direct(data)
 bundle agent delete_firewalld_direct
 {
   files:
-      #"/etc/firewalld/direct.xml"
-      "/tmp/direct.xml"
+      "$(firewalld_config.directory)/direct.xml"
           delete   => tidy,
           handle   => "deleted_firewalld_direct",
           pathtype => "literal",
@@ -130,14 +133,13 @@ bundle agent delete_firewalld_direct
 bundle agent firewalld_configuration(data)
 {
   files:
-      #"/etc/firewalld/firewalld.conf"
-      "/tmp/firewalld.conf"
+      "$(firewalld_config.directory)/firewalld.conf"
           create          => "true",
           handle          => "configured_firewalld",
           perms           => mog("0644","$(this.promiser_uid)","$(this.promiser_gid)"),
           edit_template   => "$(this.promise_dirname)/templates/firewalld_conf.mustache",
           template_method => "mustache",
-          template_data   => parsejson("$(data)"),
+          template_data   => mergedata(data),
           classes         => if_repaired("repaired_firewalld"),
           pathtype        => "literal",
           comment         => "Configure firewalld.conf";

--- a/firewalld.cf
+++ b/firewalld.cf
@@ -2,7 +2,7 @@ bundle common firewalld_config
 {
   vars:
       "directory" string => ifelse("TEST", "/tmp/firewalld",
-                                  "/etc/firewalld/services");
+                                   "/etc/firewalld/services");
       "service_directory" string => "$(directory)/services";
       "zone_directory" string => "$(directory)/zones";
 }
@@ -14,15 +14,15 @@ bundle agent create_firewalld_service(name,data)
 {
   files:
       "$(firewalld_config.service_directory)/$(name).xml"
-          create          => "true",
-          handle          => "created_firewalld_$(name)_service",
-          pathtype        => "literal",
-          edit_template   => "$(this.promise_dirname)/templates/firewalld_service.mustache",
-          perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
-          classes         => if_repaired("repaired_firewalld"),
-          template_method => "mustache",
-          template_data   => mergedata(data),
-          comment         => "Create firewalld service '$(name)'";
+      create          => "true",
+      handle          => "created_firewalld_$(name)_service",
+      pathtype        => "literal",
+      edit_template   => "$(this.promise_dirname)/templates/firewalld_service.mustache",
+      perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
+      classes         => if_repaired("repaired_firewalld"),
+      template_method => "mustache",
+      template_data   => mergedata(data),
+      comment         => "Create firewalld service '$(name)'";
 
   commands:
     repaired_firewalld::
@@ -36,11 +36,11 @@ bundle agent delete_firewalld_service(name)
 {
   files:
       "$(firewalld_config.service_directory)/$(name).xml"
-          delete   => tidy,
-          handle   => "deleted_firewalld_$(name)_service",
-          pathtype => "literal",
-          classes  => if_repaired("repaired_firewalld"),
-          comment  => "Delete firewalld service '$(name)'";
+      delete   => tidy,
+      handle   => "deleted_firewalld_$(name)_service",
+      pathtype => "literal",
+      classes  => if_repaired("repaired_firewalld"),
+      comment  => "Delete firewalld service '$(name)'";
 
   commands:
     repaired_firewalld::
@@ -54,15 +54,15 @@ bundle agent create_firewalld_zone(name,data)
 {
   files:
       "$(firewalld_config.zone_directory)/$(name).xml"
-          create          => "true",
-          handle          => "created_firewalld_$(name)_zone",
-          pathtype        => "literal",
-          edit_template   => "$(this.promise_dirname)/templates/firewalld_zone.mustache",
-          perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
-          classes         => if_repaired("repaired_firewalld"),
-          template_method => "mustache",
-          template_data   => mergedata(data),
-          comment         => "Create firewalld zone '$(name)'";
+      create          => "true",
+      handle          => "created_firewalld_$(name)_zone",
+      pathtype        => "literal",
+      edit_template   => "$(this.promise_dirname)/templates/firewalld_zone.mustache",
+      perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
+      classes         => if_repaired("repaired_firewalld"),
+      template_method => "mustache",
+      template_data   => mergedata(data),
+      comment         => "Create firewalld zone '$(name)'";
 
   commands:
     repaired_firewalld::
@@ -76,11 +76,11 @@ bundle agent delete_firewalld_zone(name)
 {
   files:
       "$(firewalld_config.zone_directory)/$(name).xml"
-          delete   => tidy,
-          handle   => "deleted_firewalld_$(name)_zone",
-          pathtype => "literal",
-          classes  => if_repaired("repaired_firewalld"),
-          comment  => "Delete firewalld zone '$(name)'";
+      delete   => tidy,
+      handle   => "deleted_firewalld_$(name)_zone",
+      pathtype => "literal",
+      classes  => if_repaired("repaired_firewalld"),
+      comment  => "Delete firewalld zone '$(name)'";
 
   commands:
     repaired_firewalld::
@@ -94,15 +94,15 @@ bundle agent create_firewalld_direct(data)
 {
   files:
       "$(firewalld_config.directory)/direct.xml"
-          create          => "true",
-          handle          => "created_firewalld_direct.xml",
-          pathtype        => "literal",
-          edit_template   => "$(this.promise_dirname)/templates/firewalld_direct.mustache",
-          perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
-          classes         => if_repaired("repaired_firewalld"),
-          template_method => "mustache",
-          template_data   => mergedata(data),
-          comment         => "Create firewalld direct.xml";
+      create          => "true",
+      handle          => "created_firewalld_direct.xml",
+      pathtype        => "literal",
+      edit_template   => "$(this.promise_dirname)/templates/firewalld_direct.mustache",
+      perms           => mog("0640","$(this.promiser_uid)","$(this.promiser_gid)"),
+      classes         => if_repaired("repaired_firewalld"),
+      template_method => "mustache",
+      template_data   => mergedata(data),
+      comment         => "Create firewalld direct.xml";
 
   commands:
     repaired_firewalld::
@@ -116,11 +116,11 @@ bundle agent delete_firewalld_direct
 {
   files:
       "$(firewalld_config.directory)/direct.xml"
-          delete   => tidy,
-          handle   => "deleted_firewalld_direct",
-          pathtype => "literal",
-          classes  => if_repaired("repaired_firewalld"),
-          comment  => "Delete firewalld direct.xml";
+      delete   => tidy,
+      handle   => "deleted_firewalld_direct",
+      pathtype => "literal",
+      classes  => if_repaired("repaired_firewalld"),
+      comment  => "Delete firewalld direct.xml";
 
   commands:
     repaired_firewalld::
@@ -134,15 +134,15 @@ bundle agent firewalld_configuration(data)
 {
   files:
       "$(firewalld_config.directory)/firewalld.conf"
-          create          => "true",
-          handle          => "configured_firewalld",
-          perms           => mog("0644","$(this.promiser_uid)","$(this.promiser_gid)"),
-          edit_template   => "$(this.promise_dirname)/templates/firewalld_conf.mustache",
-          template_method => "mustache",
-          template_data   => mergedata(data),
-          classes         => if_repaired("repaired_firewalld"),
-          pathtype        => "literal",
-          comment         => "Configure firewalld.conf";
+      create          => "true",
+      handle          => "configured_firewalld",
+      perms           => mog("0644","$(this.promiser_uid)","$(this.promiser_gid)"),
+      edit_template   => "$(this.promise_dirname)/templates/firewalld_conf.mustache",
+      template_method => "mustache",
+      template_data   => mergedata(data),
+      classes         => if_repaired("repaired_firewalld"),
+      pathtype        => "literal",
+      comment         => "Configure firewalld.conf";
 
   commands:
     repaired_firewalld::

--- a/firewalld.cf
+++ b/firewalld.cf
@@ -5,6 +5,8 @@ bundle common firewalld_config
                                    "/etc/firewalld/services");
       "service_directory" string => "$(directory)/services";
       "zone_directory" string => "$(directory)/zones";
+      "exec_prefix" string => ifelse("TEST", "/bin/echo ",
+                                    "");
 }
 
 #
@@ -26,7 +28,7 @@ bundle agent create_firewalld_service(name,data)
 
   commands:
     repaired_firewalld::
-      "/bin/echo /usr/bin/firewall-cmd --reload";
+      "$(firewalld_config.exec_prefix)/usr/bin/firewall-cmd --reload";
 }
 
 #
@@ -44,7 +46,7 @@ bundle agent delete_firewalld_service(name)
 
   commands:
     repaired_firewalld::
-      "/bin/echo /usr/bin/firewall-cmd --reload";
+      "$(firewalld_config.exec_prefix)/usr/bin/firewall-cmd --reload";
 }
 
 #
@@ -66,7 +68,7 @@ bundle agent create_firewalld_zone(name,data)
 
   commands:
     repaired_firewalld::
-      "/bin/echo /usr/bin/firewall-cmd --reload";
+      "$(firewalld_config.exec_prefix)/usr/bin/firewall-cmd --reload";
 }
 
 #
@@ -84,7 +86,7 @@ bundle agent delete_firewalld_zone(name)
 
   commands:
     repaired_firewalld::
-      "/bin/echo /usr/bin/firewall-cmd --reload";
+      "$(firewalld_config.exec_prefix)/usr/bin/firewall-cmd --reload";
 }
 
 #
@@ -106,7 +108,7 @@ bundle agent create_firewalld_direct(data)
 
   commands:
     repaired_firewalld::
-      "/bin/echo /usr/bin/firewall-cmd --reload";
+      "$(firewalld_config.exec_prefix)/usr/bin/firewall-cmd --reload";
 }
 
 #
@@ -124,7 +126,7 @@ bundle agent delete_firewalld_direct
 
   commands:
     repaired_firewalld::
-      "/bin/echo /usr/bin/firewall-cmd --reload";
+      "$(firewalld_config.exec_prefix)/usr/bin/firewall-cmd --reload";
 }
 
 #
@@ -146,5 +148,5 @@ bundle agent firewalld_configuration(data)
 
   commands:
     repaired_firewalld::
-      "/bin/echo /sbin/service firewalld restart";
+      "$(firewalld_config.exec_prefix)/sbin/service firewalld restart";
 }


### PR DESCRIPTION
- cleaned up includes, uses stdlib by default
- respect `TEST` class instead of commenting out filenames
- respect `TEST` class for running the firewalld reload commands
- pass data containers
- add convenience test Makefile
- reindent according to CFE style guide (using reindent.pl from the core) (optional, if you want it in a separate commit)

After these simple fixes, if you're interested in working on this further, it could easily be turned into a Design Center sketch and packaged with CFEngine.  I can help you do it; you're already almost there.
