### PR TITLE
Removed "/services" from $(directory) variable in firewalld_config

### DIFF
--- a/firewalld.cf
+++ b/firewalld.cf
@@ -2,7 +2,7 @@ bundle common firewalld_config
 {
   vars:
       "directory" string => ifelse("TEST", "/tmp/firewalld",
-                                   "/etc/firewalld/services");
+                                   "/etc/firewalld");
       "service_directory" string => "$(directory)/services";
       "zone_directory" string => "$(directory)/zones";
       "exec_prefix" string => ifelse("TEST", "/bin/echo ",


### PR DESCRIPTION
There's an errant "/services" appended to the $(directory) variable in the firewalld_config bundle. This causes the actual services directory to be /etc/firewalld/services/services, which doesn't work out as well. 
